### PR TITLE
Mark some functions `public`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "IncrementalSVD"
 uuid = "de227602-7e15-40a7-b166-bbaff82a52b8"
 authors = ["Tim Holy <tim.holy@gmail.com>"]
-version = "1.0.1"
+version = "1.0.2"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/IncrementalSVD.jl
+++ b/src/IncrementalSVD.jl
@@ -3,6 +3,9 @@ module IncrementalSVD
 using LinearAlgebra
 
 export isvd
+@static if VERSION >= v"1.11"
+    eval(Meta.parse("public Cache, update!, impute_nans!"))
+end
 
 """
 IncrementalSVD implements incremental singular value decomposition.


### PR DESCRIPTION
These are all documented and intended for external callers. `Cache` and `update!` are clearly too generic to export; `impute_nans!` is a bit more borderline, but we can always decide to export it later, so marking it `public` represents a forward step without risking regret and breaking changes.