### PR TITLE
Fix TagBot: drop unusable SSH deploy key

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -12,7 +12,7 @@ permissions:
   checks: read
   contents: write
   deployments: read
-  issues: read
+  issues: write
   discussions: read
   packages: read
   pages: read
@@ -28,6 +28,3 @@ jobs:
       - uses: JuliaRegistries/TagBot@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          # Edit the following line to reflect the actual name of the GitHub Secret containing your private key
-          ssh: ${{ secrets.DOCUMENTER_KEY }}
-          # ssh: ${{ secrets.NAME_OF_MY_SSH_PRIVATE_KEY_SECRET }}


### PR DESCRIPTION
## Problem

v1.0.2 has been in the General registry for a week, but no `v1.0.2` git tag or GitHub release exists.

TagBot **is** firing — it has run dozens of times — but every run since v1.0.2 was registered fails at the tag-push step:

```
SSH key authentication failed: Permission denied. Verify the deploy key is added to the repository and has write access.
...
git@github.com: Permission denied (publickey).
##[error]Failed to push tag v1.0.2
```

## Cause

`TagBot.yml` passed `ssh: ${{ secrets.DOCUMENTER_KEY }}`. The `DOCUMENTER_KEY` secret exists, but the repository has **no deploy keys** at all, so the private key has no matching write-access public key — the push is rejected. When `ssh:` is set, TagBot pushes over SSH and does not fall back to `GITHUB_TOKEN`, so the orphaned key blocks tagging entirely. There is no `docs/` deployment, so `DOCUMENTER_KEY` is unused leftover setup.

The failure went unnoticed because TagBot's attempt to open an issue flagging it got a `403` — `TagBot.yml` declared `issues: read`.

## Fix

- Drop the `ssh:` line so the tag is pushed with `GITHUB_TOKEN` (default workflow permissions are already `write`; the v1.0.2 commit touches no workflow files).
- Grant `issues: write` so a future failed release surfaces as an issue rather than silently 403-ing.

After merge, TagBot will be run via `workflow_dispatch` to tag and release v1.0.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)