### PR TITLE
Make the ISVD test robust against ill-conditioning and sign ambiguity

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,8 +18,14 @@ end
 
 @testset "ISVD" begin
     r = 5
-    A = rand(20, r)
-    B = rand(r, 30)
+    # Build a rank-`r` target `M = A*B` with well-separated singular values
+    # (5, 4, 3, 2, 1). With a poorly-conditioned target the trailing singular
+    # vector is only weakly determined, and independent incremental SVD
+    # computations can disagree on it by more than the default tolerance.
+    QA = Matrix(qr(randn(20, r)).Q)[:, 1:r]
+    QB = Matrix(qr(randn(30, r)).Q)[:, 1:r]
+    A = QA * Diagonal(Float64.(r:-1:1))
+    B = QB'
     M = A*B
     U = s = nothing
     for j = 1:r:size(M,2)
@@ -30,17 +36,23 @@ end
     pA = U*(U'*A)
     @test pA ≈ A
 
-    # Compare with `isvd`
+    # Compare with `isvd`. Singular vectors are determined only up to sign, so
+    # compare columnwise allowing a flip.
     U2, s2 = isvd(M, r)
-    @test U2 ≈ U
+    for (col1, col2) in zip(eachcol(U), eachcol(U2))
+        @test col1 ≈ col2 || col1 ≈ -col2
+    end
     @test s2 ≈ s
 
     # Check online calculation of Vt
     Vt = Diagonal(s) \ (U' * M)
     U2, s2, Vt2 = isvd_with_Vt(M, r)
-    @test U2 ≈ U
+    for (col1, col2) in zip(eachcol(U), eachcol(U2))
+        @test col1 ≈ col2 || col1 ≈ -col2
+    end
     @test s2 ≈ s
-    @test Vt2[:,end-r+1:end] ≈ Vt[:,end-r+1:end]
+    # A sign flip in a column of `U` flips the corresponding row of `Vt`.
+    @test abs.(Vt2[:,end-r+1:end]) ≈ abs.(Vt[:,end-r+1:end])
     @test norm(M - U*Diagonal(s)*Vt) <= norm(M - U2*Diagonal(s2)*Vt2)
 
     # Unequal-sized blocks


### PR DESCRIPTION
## Problem

The `@testset "ISVD"` fails intermittently — it failed on the `Julia min` CI job of #26, at `test/runtests.jl`'s `U2 ≈ U` comparison.

The test built its target as `M = A*B` with `A = rand(20, 5)`, `B = rand(5, 30)`. Two independent issues made it flaky:

1. **No headroom in the target.** `rand` entries are all positive, so M is dominated by a rank-one "mean" component and has a lopsided spectrum — σ₅/σ₁ frequently lands at 0.02–0.06. The trailing singular vector is then only weakly determined, and the two incremental SVD paths the test compares (`update!` from a `nothing` start vs. `isvd` from a zero-filled start) disagree on it by more than the default `isapprox` tolerance. Measured rate: ~0.7% of random draws.

2. **Sign ambiguity.** Left singular vectors are determined only up to sign, and the two paths occasionally pick opposite signs for a column. `@test U2 ≈ U` ignores this — even with a well-conditioned target, ~0.03% of draws fail on a clean sign flip. The test already handles this correctly for its unequal-block comparisons (`col1 ≈ col2 || col1 ≈ -col2`) but not here.

## Fix

- Build M from orthonormal factors with an explicit, well-separated set of singular values (5, 4, 3, 2, 1), so every singular vector is pinned down to full precision. No seeded RNG — the stream is not stable across Julia versions; the headroom is structural instead.
- Compare `U` columnwise allowing a sign flip (matching the idiom already used elsewhere in the file). The sign-coupled rows of `Vt` are compared by magnitude.

## Verification

- Core comparisons (`pA ≈ A`, sign-aware `U2 ≈ U`, `s2 ≈ s`): **0 failures over 80,000 random trials** on both Julia 1.10 and 1.12 — vs. ~206/30,000 with the old construction.
- Full edited testset: **0 failures over 500 runs**.
- `Pkg.test()` passes (37/37).

🤖 Generated with [Claude Code](https://claude.com/claude-code)